### PR TITLE
RED-9429 Missing links for multiple participant role

### DIFF
--- a/multipleparticipantroleforevent.php
+++ b/multipleparticipantroleforevent.php
@@ -113,10 +113,19 @@ function multipleparticipantroleforevent_civicrm_alterSettingsFolders(&$metaData
 function multipleparticipantroleforevent_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Event_Form_Registration_Register' || $formName == 'CRM_Event_Form_Registration_Confirm' || $formName == 'CRM_Event_Form_ManageEvent_EventInfo') {
 
+
       $allParticipantRoles    = CRM_Event_PseudoConstant::participantRole();
       if ($formName == 'CRM_Event_Form_ManageEvent_EventInfo') {
         $form->assign("allParticipantRoles", $allParticipantRoles);
         $form->assign("eventID", $form->_id);
+        
+        //MV #9429 EventInfo.extra.tpl has been used in other extensions, so better have custom tpl
+        //and inject into page-body to avoid conflicts
+        $templatePath = realpath(dirname(__FILE__)."/templates");
+        // dynamically insert a template block in the page
+        CRM_Core_Region::instance('page-body')->add(array(
+          'template' => "{$templatePath}/CRM/Event/Form/ManageEvent/MultipleParticipantRoleLinks.tpl"
+        ));
       } else {
         $participantrole = '';
         $participantroleHashed = CRM_Utils_Request::retrieve('participantrole', 'String', $form);

--- a/templates/CRM/Event/Form/ManageEvent/MultipleParticipantRoleLinks.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/MultipleParticipantRoleLinks.tpl
@@ -23,7 +23,7 @@
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
 *}
-{if $eventID}
+{if $eventID && $isForm}
 <br/>
 <div id="registration-urls-with-different-participant-role" class="crm-accordion-wrapper">
   <div class="crm-accordion-header">
@@ -45,7 +45,6 @@
   </ul>
   </div>
 </div>
-{/if}
 {literal}
   <style type="text/css">
     .ui-tooltip {
@@ -85,8 +84,11 @@
       cj(".ui-tooltip-content").parents('div').remove();
     });
     cj("#registration-urls-with-different-participant-role").appendTo("#EventInfo > div.crm-event-manage-eventinfo-form-block > table > tbody > tr > td > strong");
-    cj.unique( "#registration-urls-with-different-participant-role" );
+    //MV #8072, Using unique returns TypeError on Event contfiguration page.
+    // cj.unique( "#registration-urls-with-different-participant-role" );
+    //use of unique is to remove all duplciates (if any), to achieve this using nextall and remove instead of unique.
+    cj("#registration-urls-with-different-participant-role").nextAll().remove();
   });
 </script>
 {/literal}
-
+{/if}


### PR DESCRIPTION
In some case, Multiple participant role links in Event info page is disappeared when EventInfo.extra.tpl has been used/overridden in other extension.

To avoid this situation, Injecting the tpl in Page body instead of using EventInfo.extra.tpl. 